### PR TITLE
Skip database connection in staging for load balancer health checks

### DIFF
--- a/app/controllers/monitors_controller.rb
+++ b/app/controllers/monitors_controller.rb
@@ -2,7 +2,7 @@ class MonitorsController < ApplicationController
   # skip_before_action :require_login, raise: false
 
   def lb
-    User.first
+    User.first unless Rails.env.staging?
     render plain: "OK"
   end
 end


### PR DESCRIPTION
This will allow the Neon database to scale to 0.