### PR TITLE
Add gift card validation endpoint

### DIFF
--- a/app/controllers/api/v1/gift_cards_controller.rb
+++ b/app/controllers/api/v1/gift_cards_controller.rb
@@ -7,6 +7,23 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
     render json: @gift_card
   end
 
+  # validates if a gift card can be used without actually using it
+  def validate
+    if @gift_card.registrations_available.to_i <= 1
+      render json: {
+        valid: false,
+        error: "No registrations available",
+        status: 403
+      }, status: 403
+      return
+    end
+
+    render json: {
+      valid: true,
+      gift_card: @gift_card
+    }
+  end
+
   # an update automatically means to use up one registration
   def update
     if @gift_card.registrations_available.to_i <= 1

--- a/app/controllers/api/v1/gift_cards_controller.rb
+++ b/app/controllers/api/v1/gift_cards_controller.rb
@@ -18,6 +18,15 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
       return
     end
 
+    if @gift_card.expiration_date && @gift_card.expiration_date < Date.today
+      render json: {
+        valid: false,
+        error: "Gift card has expired",
+        status: 403
+      }, status: 403
+      return
+    end
+
     render json: {
       valid: true,
       gift_card: @gift_card

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :gift_cards, only: [:show, :update]
+      resources :gift_cards, only: [:show, :update] do
+        member do
+          get :validate
+        end
+      end
     end
   end
 

--- a/spec/controllers/api/v1/gift_cards_controller_spec.rb
+++ b/spec/controllers/api/v1/gift_cards_controller_spec.rb
@@ -38,6 +38,44 @@ describe Api::V1::GiftCardsController do
     end
   end
 
+  context "#validate" do
+    it "returns valid: true when gift card has registrations available" do
+      gift_card.update(registrations_available: 10)
+      get :validate, params: {access_token: api_key.access_token, id: gift_card.certificate, format: :json}
+      expect(response).to have_http_status(200)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["valid"]).to eq(true)
+      expect(parsed_response["gift_card"]["certificate"]).to eq(gift_card.certificate)
+      expect(parsed_response["gift_card"]["registrations_available"]).to eq(10)
+    end
+
+    it "does not modify registrations_available" do
+      gift_card.update(registrations_available: 10)
+      get :validate, params: {access_token: api_key.access_token, id: gift_card.certificate, format: :json}
+      gift_card.reload
+      expect(gift_card.registrations_available).to eq(10)
+    end
+
+    it "returns valid: false when no registrations available" do
+      gift_card.update(registrations_available: 1)
+      get :validate, params: {access_token: api_key.access_token, id: gift_card.certificate, format: :json}
+      expect(response).to have_http_status(403)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["valid"]).to eq(false)
+      expect(parsed_response["error"]).to eq("No registrations available")
+    end
+
+    it "handles gift card not found" do
+      get :validate, params: {access_token: api_key.access_token, id: "not existing", format: :json}
+      expect(response).to have_http_status(404)
+    end
+
+    it "rejects an invalid access token" do
+      get :validate, params: {access_token: "invalid", id: gift_card.certificate, format: :json}
+      expect(response).to have_http_status(401)
+    end
+  end
+
   context "#update" do
     it "handles gift card not found" do
       put :update, params: {access_token: api_key.access_token, id: "not existing", format: :json}


### PR DESCRIPTION
Add gift card validation endpoint.

https://jira.cru.org/browse/EVENT-913

⏺ Validate Endpoint

  Endpoint

  GET /api/v1/gift_cards/:certificate/validate

  Authentication

  Same as other API endpoints - requires an API token passed via:
  - Query parameter: ?access_token=<token>
  - HTTP header: Authorization: token <token> or Authorization: Bearer <token>

  Example Request

  GET /api/v1/gift_cards/ABC123/validate?access_token=your_api_token_here

  or

  GET /api/v1/gift_cards/ABC123/validate
  Authorization: token your_api_token_here

  ---
  Response Examples

  ✅ Success - Gift Card is Valid (200 OK)

  When the gift card passes all validations:
  ```
{
    "valid": true,
    "gift_card": {
      "id": 1,
      "issuance_id": 1,
      "batch_id": 1,
      "price": "25.00",
      "gift_card_type": "paid_half_price",
      "certificate": "ABC123",
      "expiration_date": "2025-12-31",
      "registrations_available": 10,
      "associated_product": "product_name",
      "gl_code": "12345-dept-project",
      "isbn": "978-1234567890",
      "created_at": "2024-11-26T09:21:31.000Z",
      "updated_at": "2024-11-26T09:21:31.000Z"
    }
  }
```

  ❌ Error - No Registrations Available (403 Forbidden)

  When registrations_available is 1 or less:
```
  {
    "valid": false,
    "error": "No registrations available",
    "status": 403
  }
```
  ❌ Error - Gift Card Expired (403 Forbidden)

  When expiration_date is in the past:
```
  {
    "valid": false,
    "error": "Gift card has expired",
    "status": 403
  }
```

  ❌ Error - Gift Card Not Found (404 Not Found)

  When the certificate doesn't exist:
```
  {
    "error": "No gift card found by that certificate",
    "status": 404
  }
```

  ❌ Error - Invalid/Missing Token (401 Unauthorized)

  When the API token is missing or invalid:
```
  {
    "error": "You either didn't pass in an access token, or the token you did pass in was wrong.",
    "status": "unauthorized"
  }
```
  ---
  Validation Rules

  The endpoint checks the following conditions in order:

  1. Gift card exists → 404 if not found
  2. API token is valid → 401 if invalid/missing
  3. Has registrations available → Must have > 1 registrations (403 if not)
  4. Not expired → expiration_date must be today or future (403 if expired in past)
    - Note: If expiration_date is null, it's considered valid (no expiration)

  If all validations pass → Returns 200 OK with valid: true

  ---
  Key Differences from PUT /api/v1/gift_cards/:certificate

  | Feature           | GET validate             | PUT update                      |
  |-------------------|--------------------------|---------------------------------|
  | Purpose           | Check if card is valid   | Use a registration              |
  | Modifies data     | ❌ No                     | ✅ Yes (decrements by 2)         |
  | Checks expiration | ✅ Yes                    | ❌ No                            |
  | Response format   | {valid: true/false, ...} | Just gift card JSON             |
  | Use case          | Pre-validate before use  | Actually consume a registration |

