### PR TITLE
Add expiration check to redemption endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     bundler-audit (0.9.2)

--- a/app/controllers/api/v1/gift_cards_controller.rb
+++ b/app/controllers/api/v1/gift_cards_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
       render json: {
         error: "No registrations available",
         status: 403
-      }, status: 403
+      }, status: :forbidden
       return
     end
 
@@ -21,7 +21,7 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
       render json: {
         error: "Gift card has expired",
         status: 403
-      }, status: 403
+      }, status: :forbidden
       return
     end
 
@@ -38,7 +38,7 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
       render json: {
         error: "No gift card found by that certificate",
         status: 404
-      }, status: 404
+      }, status: :not_found
     end
   end
 end

--- a/app/controllers/api/v1/gift_cards_controller.rb
+++ b/app/controllers/api/v1/gift_cards_controller.rb
@@ -17,6 +17,14 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
       return
     end
 
+    if @gift_card.expired?
+      render json: {
+        error: "Gift card has expired",
+        status: 403
+      }, status: 403
+      return
+    end
+
     @gift_card.update(registrations_available: @gift_card.registrations_available - 2)
     render json: @gift_card
   end

--- a/app/models/gift_card.rb
+++ b/app/models/gift_card.rb
@@ -17,6 +17,10 @@ class GiftCard < ApplicationRecord
 
   validates :certificate, uniqueness: true
 
+  def expired?
+    expiration_date.present? && expiration_date < Date.current
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     %w[certificate expiration_date registrations_available associated_product gl_code created_at updated_at
       issuance_id gift_card_type isbn batch_id price gift_card_type]

--- a/spec/controllers/api/v1/gift_cards_controller_spec.rb
+++ b/spec/controllers/api/v1/gift_cards_controller_spec.rb
@@ -48,6 +48,14 @@ describe Api::V1::GiftCardsController do
       gift_card.update(registrations_available: 1)
       put :update, params: {access_token: api_key.access_token, id: gift_card.certificate, format: :json}
       expect(response).to have_http_status(403)
+      expect(JSON.parse(response.body)["error"]).to eq("No registrations available")
+    end
+
+    it "handles an expired gift card" do
+      gift_card.update(registrations_available: 10, expiration_date: 1.day.ago)
+      put :update, params: {access_token: api_key.access_token, id: gift_card.certificate, format: :json}
+      expect(response).to have_http_status(403)
+      expect(JSON.parse(response.body)["error"]).to eq("Gift card has expired")
     end
 
     it "subtracts 2 from registrations_available" do


### PR DESCRIPTION
Patches a bug where an expired gift card was stiill redeemable.

Staging gift card id: 5000000260 was successfully redeemed today despite expiring 1/24/25.