### PR TITLE
update wording per FL request

### DIFF
--- a/app/controllers/api/v1/gift_cards_controller.rb
+++ b/app/controllers/api/v1/gift_cards_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::GiftCardsController < Api::V1::ApplicationController
 
     unless @gift_card
       render json: {
-        error: "No gift card found by that certificate",
+        error: "No gift card found by that number",
         status: 404
       }, status: :not_found
     end


### PR DESCRIPTION
During UAT in ERT FL didn't like the language of this.

I think there's an argument to be made that this should instead be done in ERT, since this is a presentation concern.
The reason i did it here is because the ERT doesn't do any rewording of this message, it just presents it to the user as is.
Additionally, it feels like the message was worded in a way that it was supposed to be presented to the user, something like `invalid certificate` might be used if this was intended to be used to inform an API.

IDK, let me know what you think.